### PR TITLE
fix: Always resolve local dependencies to the most specific route

### DIFF
--- a/.changeset/yellow-mammals-type.md
+++ b/.changeset/yellow-mammals-type.md
@@ -1,0 +1,6 @@
+---
+"jsrepo": patch
+---
+
+fix: Always resolve to local dependencies to most specific path
+  

--- a/package.json
+++ b/package.json
@@ -15,16 +15,7 @@
 	"bugs": {
 		"url": "https://github.com/jsrepojs/jsrepo/issues"
 	},
-	"keywords": [
-		"repo",
-		"cli",
-		"svelte",
-		"vue",
-		"typescript",
-		"javascript",
-		"shadcn",
-		"registry"
-	],
+	"keywords": ["repo", "cli", "svelte", "vue", "typescript", "javascript", "shadcn", "registry"],
 	"type": "module",
 	"packageManager": "pnpm@10.8.1",
 	"exports": {
@@ -35,10 +26,7 @@
 	},
 	"bin": "./dist/index.js",
 	"main": "./dist/index.js",
-	"files": [
-		"./schemas/**/*",
-		"dist/**/*"
-	],
+	"files": ["./schemas/**/*", "dist/**/*"],
 	"scripts": {
 		"start": "tsup --silent && node ./dist/index.js",
 		"build": "tsup",

--- a/tests/providers.test.ts
+++ b/tests/providers.test.ts
@@ -635,17 +635,21 @@ describe('gitlab', () => {
 	});
 
 	// this is just here to make sure fetch manifest is actually using the right url
-	it('Fails to fetch with incorrect prefixed url', async () => {
-		const repoURL = 'gitlab:https://gitlab.om/ieedan/std';
+	it(
+		'Fails to fetch with incorrect prefixed url',
+		async () => {
+			const repoURL = 'gitlab:https://gitlab.om/ieedan/std';
 
-		const providerState = await registry.getProviderState(repoURL);
+			const providerState = await registry.getProviderState(repoURL);
 
-		assert(providerState.isOk());
+			assert(providerState.isOk());
 
-		const content = await registry.fetchManifest(providerState.unwrap());
+			const content = await registry.fetchManifest(providerState.unwrap());
 
-		expect(content.isErr()).toBe(true);
-	});
+			expect(content.isOk()).toBe(true);
+		},
+		{ fails: true }
+	);
 });
 
 describe('bitbucket', () => {

--- a/tests/providers.test.ts
+++ b/tests/providers.test.ts
@@ -635,21 +635,17 @@ describe('gitlab', () => {
 	});
 
 	// this is just here to make sure fetch manifest is actually using the right url
-	it(
-		'Fails to fetch with incorrect prefixed url',
-		async () => {
-			const repoURL = 'gitlab:https://gitlab.om/ieedan/std';
+	it('Fails to fetch with incorrect prefixed url', async () => {
+		const repoURL = 'gitlab:https://gitlab.om/ieedan/std';
 
-			const providerState = await registry.getProviderState(repoURL);
+		const providerState = await registry.getProviderState(repoURL);
 
-			assert(providerState.isOk());
+		assert(providerState.isOk());
 
-			const content = await registry.fetchManifest(providerState.unwrap());
+		const content = await registry.fetchManifest(providerState.unwrap());
 
-			expect(content.isOk()).toBe(true);
-		},
-		{ fails: true }
-	);
+		expect(content.isErr()).toBe(true);
+	});
 });
 
 describe('bitbucket', () => {


### PR DESCRIPTION
Fixes #548 

This is a bit of a hack that warrants some explanation. Previously having multiple nested paths was a bit risky because you could potentially end up resolving to a path that was not the block you were actually referencing. Essentially since the resolution was based on the order of `dirs` in your build config it was hard to tell how things would be resolved.

With this PR we always resolve to the most specific (longest) path. 

Take for example this project structure:

```
root
├── /src
│   └── /lib
│       └── /components
│           └── /ui
└── ...
```

If I have 2 dirs in my build config:
```jsonc
{
	"dirs": ["./src/lib", "./src/lib/components"]
}
```

When a block outside of `src/lib` tries to reference `src/lib/components/ui/button` previously jsrepo would immediately match to `src/lib` and try to resolve the button as a block called `components/ui`. Now since we check what the most specific path is it will correctly resolve to `ui/button`.

This shouldn't be breaking for anyone since any project effected would have previously resulted in an error during build anyways.