### PR TITLE
feat(mcp): `add-component` tool

### DIFF
--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -1,8 +1,0 @@
-{
-	"mcpServers": {
-		"jsrepo": {
-			"command": "node",
-			"args": ["./dist/index.js", "mcp"]
-		}
-	}
-}

--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -1,0 +1,8 @@
+{
+	"mcpServers": {
+		"jsrepo": {
+			"command": "node",
+			"args": ["./dist/index.js", "mcp"]
+		}
+	}
+}

--- a/src/utils/mcp.ts
+++ b/src/utils/mcp.ts
@@ -368,6 +368,7 @@ async function addComponent({ component, cwd }: AddComponentArgs) {
 	}
 
 	return {
+		// this just lets the agent know where the component was added
 		addedToPath: paths[specifier.split('/')[0]] || paths['*'],
 	};
 }


### PR DESCRIPTION
This tool (while a little jank) allows you to add components through the mcp server while notifying the agent where they are located. 

From my testing with cursor it really wanted to import from the wrong place or just add the code for the component directly wherever you were working because it didn't know where the components had been added in your project if you ran a suggested command.

This will run the command and return the path where the component was added.