### PR TITLE
feat: Default category paths

### DIFF
--- a/.changeset/curvy-cloths-wish.md
+++ b/.changeset/curvy-cloths-wish.md
@@ -1,0 +1,6 @@
+---
+"jsrepo": minor
+---
+
+feat: Allow registry owners to configure default paths for their users
+  

--- a/schemas/registry-config.json
+++ b/schemas/registry-config.json
@@ -25,6 +25,14 @@
 			"default": "public",
 			"enum": ["public", "private", "marketplace"]
 		},
+		"defaultPaths": {
+			"type": "object",
+			"description": "A map of category names to default paths for the registry.",
+			"additionalProperties": {
+				"type": "string",
+				"description": "The default path for the given category."
+			}
+		},
 		"meta": {
 			"description": "Optional metadata to include in the manifest file.",
 			"type": "object",

--- a/src/types.ts
+++ b/src/types.ts
@@ -68,6 +68,7 @@ export const manifestSchema = v.object({
 	version: v.optional(v.string()),
 	meta: v.optional(manifestMeta),
 	access: v.optional(accessLevel),
+	defaultPaths: v.optional(v.record(v.string(), v.string())),
 	peerDependencies: v.optional(peerDependencySchema),
 	configFiles: v.optional(v.array(manifestConfigFileSchema)),
 	categories: v.array(categorySchema),

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -69,6 +69,7 @@ export const registryConfigSchema = v.object({
 	readme: v.optional(v.string(), 'README.md'),
 	access: v.optional(accessLevel),
 	meta: v.optional(manifestMeta),
+	defaultPaths: v.optional(v.record(v.string(), v.string())),
 	peerDependencies: v.optional(peerDependencySchema),
 	configFiles: v.optional(v.array(configFileSchema)),
 	dirs: v.array(v.string()),

--- a/src/utils/manifest.ts
+++ b/src/utils/manifest.ts
@@ -51,6 +51,7 @@ export function createManifest(
 		version: config.version,
 		meta: config.meta,
 		access: config.access,
+		defaultPaths: config.defaultPaths,
 		peerDependencies: config.peerDependencies,
 		configFiles,
 		categories,


### PR DESCRIPTION
Fixes #562 

This PR introduces a `defaultPaths` key to the `jsrepo-build-config.json` file. This allows you to configure default install locations for your categories in users projects. 

For example:

```jsonc
{
	"defaultPaths": {
		"ui": "$lib/components/ui"
	}
}
```

When the user initializes their project and doesn't configure it otherwise the path will be added to their `jsrepo.json` file like so:

```jsonc
{
	"paths": {
		"ui": "$lib/components/ui"
	}
}
```