### PR TITLE
fix(build): ignore .DS_Store files during build

### DIFF
--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -10,7 +10,7 @@ import type { Category } from '../types';
 import * as ascii from '../utils/ascii';
 import { buildBlocksDirectory, buildConfigFiles, pruneUnused } from '../utils/build';
 import { DEFAULT_CONFIG, runRules } from '../utils/build/check';
-import { IGNORED_DIRS, type RegistryConfig, getRegistryConfig } from '../utils/config';
+import { IGNORED_DIRS, IGNORED_FILES, type RegistryConfig, getRegistryConfig } from '../utils/config';
 import { createManifest, parseManifest } from '../utils/manifest';
 import { intro, spinner } from '../utils/prompts';
 
@@ -180,6 +180,7 @@ async function _build(options: Options) {
 	}
 
 	ig.add(IGNORED_DIRS);
+	ig.add(IGNORED_FILES);
 
 	for (const dir of config.dirs) {
 		const dirPath = path.join(options.cwd, dir);

--- a/src/commands/publish.ts
+++ b/src/commands/publish.ts
@@ -11,7 +11,7 @@ import type { Category } from '../types';
 import * as ascii from '../utils/ascii';
 import { buildBlocksDirectory, buildConfigFiles, pruneUnused } from '../utils/build';
 import { DEFAULT_CONFIG, runRules } from '../utils/build/check';
-import { IGNORED_DIRS, type RegistryConfig, getRegistryConfig } from '../utils/config';
+import { IGNORED_DIRS, IGNORED_FILES, type RegistryConfig, getRegistryConfig } from '../utils/config';
 import { iFetch } from '../utils/fetch';
 import { createManifest } from '../utils/manifest';
 import type { PackageJson } from '../utils/package';
@@ -234,6 +234,7 @@ async function _publish(options: Options) {
 	}
 
 	ig.add(IGNORED_DIRS);
+	ig.add(IGNORED_FILES);
 
 	for (const dir of config.dirs) {
 		const dirPath = path.join(options.cwd, dir);

--- a/src/utils/build/index.ts
+++ b/src/utils/build/index.ts
@@ -80,6 +80,9 @@ export function buildBlocksDirectory(
 
 		for (const file of files) {
 			const blockDir = path.join(categoryDir, file);
+			const relativePath = path.relative(cwd, blockDir);
+			
+			if (ignore.ignores(relativePath)) continue;
 
 			if (fs.statSync(blockDir).isFile()) {
 				if (isTestFile(file)) continue;

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -17,6 +17,9 @@ import { tryGetTsconfig } from './files';
 /** sensible defaults for ignored directories */
 export const IGNORED_DIRS = ['.git', 'node_modules'] as const;
 
+/** system files that should be ignored by default */
+export const IGNORED_FILES = ['.DS_Store'] as const;
+
 export const PROJECT_CONFIG_NAME = 'jsrepo.json';
 export const REGISTRY_CONFIG_NAME = 'jsrepo-build-config.json';
 


### PR DESCRIPTION
Fix for #573 

Extends the existing `IGNORED_DIRS` system to include `IGNORED_FILES`, applies ignore checking to individual files during block processing