### PR TITLE
feat: Optionally include doc files in registry

### DIFF
--- a/.changeset/stale-kiwis-itch.md
+++ b/.changeset/stale-kiwis-itch.md
@@ -1,0 +1,6 @@
+---
+"jsrepo": minor
+---
+
+feat: Optionally include documentation files (*.md, *.mdx) in registry
+  

--- a/schemas/project-config.json
+++ b/schemas/project-config.json
@@ -12,7 +12,12 @@
 		"includeTests": {
 			"description": "When true includes the test files for each block in the same directory.",
 			"type": "boolean",
-			"default": "true"
+			"default": "false"
+		},
+		"includeDocs": {
+			"description": "When true includes the documentation files for each block in the same directory.",
+			"type": "boolean",
+			"default": "false"
 		},
 		"watermark": {
 			"description": "When true will add a watermark with the version and repository at the top of the installed files.",

--- a/schemas/registry-config.json
+++ b/schemas/registry-config.json
@@ -209,6 +209,11 @@
 			"type": "boolean",
 			"default": false
 		},
+		"includeDocs": {
+			"description": "Include documentation files (*.md, *.mdx) in the registry.",
+			"type": "boolean",
+			"default": false
+		},
 		"rules": {
 			"description": "Configure rules when checking manifest after build.",
 			"type": "object",

--- a/src/commands/add.ts
+++ b/src/commands/add.ts
@@ -36,6 +36,7 @@ import * as registry from '../utils/registry-providers/internal';
 const schema = v.object({
 	watermark: v.optional(v.boolean()),
 	tests: v.optional(v.boolean()),
+	docs: v.optional(v.boolean()),
 	formatter: v.optional(v.union([v.literal('prettier'), v.literal('biome'), v.literal('none')])),
 	paths: v.optional(v.record(v.string(), v.string())),
 	expand: v.boolean(),
@@ -70,6 +71,11 @@ export const add = new Command('add')
 	)
 	.addOption(
 		new Option('--tests <choice>', 'Include tests when adding blocks.')
+			.choices(['true', 'false'])
+			.argParser((val) => val === 'true')
+	)
+	.addOption(
+		new Option('--docs <choice>', 'Include docs when adding blocks.')
 			.choices(['true', 'false'])
 			.argParser((val) => val === 'true')
 	)
@@ -146,6 +152,7 @@ async function _add(blockNames: string[], options: Options) {
 		config = {
 			$schema: '',
 			includeTests: false,
+			includeDocs: false,
 			watermark: true,
 			paths: {
 				'*': './src/blocks',
@@ -162,6 +169,7 @@ async function _add(blockNames: string[], options: Options) {
 			: config.formatter;
 	config.watermark = options.watermark !== undefined ? options.watermark : config.watermark;
 	config.includeTests = options.tests !== undefined ? options.tests : config.includeTests;
+	config.includeDocs = options.docs !== undefined ? options.docs : config.includeDocs;
 	config.paths =
 		options.paths !== undefined ? { ...config.paths, ...options.paths } : config.paths;
 

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -28,6 +28,7 @@ const schema = v.object({
 	doNotListCategories: v.optional(v.array(v.string())),
 	allowSubdirectories: v.optional(v.boolean()),
 	preview: v.optional(v.boolean()),
+	includeDocs: v.optional(v.boolean()),
 	output: v.boolean(),
 	verbose: v.boolean(),
 	cwd: v.string(),
@@ -62,6 +63,7 @@ const build = new Command('build')
 	.option('--exclude-deps [deps...]', 'Dependencies that should not be added.')
 	.option('--allow-subdirectories', 'Allow subdirectories to be built.')
 	.option('--preview', 'Display a preview of the blocks list.')
+	.option('--include-docs', 'Include docs files (*.mdx, *.md) in the registry.')
 	.option('--no-output', `Do not output a \`${MANIFEST_FILE}\` file.`)
 	.option('--verbose', 'Include debug logs.', false)
 	.option('--cwd <path>', 'The current working directory.', process.cwd())
@@ -105,6 +107,7 @@ async function _build(options: Options) {
 					excludeCategories: options.excludeCategories ?? [],
 					allowSubdirectories: options.allowSubdirectories,
 					preview: options.preview,
+					includeDocs: options.includeDocs ?? false,
 				} satisfies RegistryConfig;
 			}
 
@@ -127,6 +130,7 @@ async function _build(options: Options) {
 			if (options.allowSubdirectories !== undefined)
 				mergedVal.allowSubdirectories = options.allowSubdirectories;
 			if (options.preview !== undefined) mergedVal.preview = options.preview;
+			if (options.includeDocs !== undefined) mergedVal.includeDocs = options.includeDocs;
 
 			mergedVal.rules = { ...DEFAULT_CONFIG, ...mergedVal.rules };
 

--- a/src/commands/exec.ts
+++ b/src/commands/exec.ts
@@ -82,6 +82,7 @@ export async function _exec(s: string | undefined, options: Options, command: an
 		config = {
 			$schema: '',
 			includeTests: false,
+			includeDocs: false,
 			watermark: true,
 			paths: {
 				'*': './',

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -51,6 +51,7 @@ const schema = v.object({
 	repos: v.optional(v.array(v.string())),
 	watermark: v.boolean(),
 	tests: v.optional(v.boolean()),
+	docs: v.optional(v.boolean()),
 	formatter: v.optional(formatterSchema),
 	paths: v.optional(v.record(v.string(), v.string())),
 	configFiles: v.optional(v.record(v.string(), v.string())),
@@ -76,6 +77,7 @@ const init = new Command('init')
 		'Will not add a watermark to each file upon adding it to your project.'
 	)
 	.option('--tests', 'Will include tests with the blocks.')
+	.option('--docs', 'Will include docs with the blocks.')
 	.addOption(
 		new Option(
 			'--formatter <formatter>',
@@ -369,6 +371,10 @@ const _initProject = async (registries: string[], options: Options) => {
 			initialConfig.isOk() && options.tests === undefined
 				? initialConfig.unwrap().includeTests
 				: (options.tests ?? false),
+		includeDocs:
+			initialConfig.isOk() && options.docs === undefined
+				? initialConfig.unwrap().includeDocs
+				: (options.docs ?? false),
 		watermark: options.watermark,
 		formatter: options.formatter,
 		configFiles,
@@ -778,6 +784,7 @@ const _initRegistry = async (options: Options) => {
 			excludeBlocks: [],
 			excludeCategories: [],
 			preview: false,
+			includeDocs: false,
 		};
 	}
 

--- a/src/commands/publish.ts
+++ b/src/commands/publish.ts
@@ -35,6 +35,7 @@ const schema = v.object({
 	doNotListBlocks: v.optional(v.array(v.string())),
 	doNotListCategories: v.optional(v.array(v.string())),
 	allowSubdirectories: v.optional(v.boolean()),
+	includeDocs: v.optional(v.boolean()),
 	verbose: v.boolean(),
 	cwd: v.string(),
 });
@@ -71,6 +72,7 @@ export const publish = new Command('publish')
 	)
 	.option('--exclude-deps [deps...]', 'Dependencies that should not be added.')
 	.option('--allow-subdirectories', 'Allow subdirectories to be built.')
+	.option('--include-docs', 'Include documentation files (*.md, *.mdx) in the registry.')
 	.option('--verbose', 'Include debug logs.', false)
 	.option('--cwd <path>', 'The current working directory.', process.cwd())
 	.action(async (opts) => {
@@ -110,6 +112,7 @@ async function _publish(options: Options) {
 					excludeBlocks: options.excludeBlocks ?? [],
 					excludeCategories: options.excludeCategories ?? [],
 					allowSubdirectories: options.allowSubdirectories,
+					includeDocs: options.includeDocs ?? false,
 				} satisfies RegistryConfig;
 			}
 
@@ -133,6 +136,7 @@ async function _publish(options: Options) {
 			if (options.excludeDeps) mergedVal.excludeDeps = options.excludeDeps;
 			if (options.allowSubdirectories !== undefined)
 				mergedVal.allowSubdirectories = options.allowSubdirectories;
+			if (options.includeDocs !== undefined) mergedVal.includeDocs = options.includeDocs;
 
 			mergedVal.rules = { ...DEFAULT_CONFIG, ...mergedVal.rules };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,6 +7,7 @@ export const blockSchema = v.object({
 	dependencies: v.array(v.string()),
 	devDependencies: v.array(v.string()),
 	tests: v.boolean(),
+	docs: v.optional(v.boolean(), false),
 	list: v.optional(v.boolean(), true),
 	/** Where to find the block relative to root */
 	directory: v.string(),

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -35,6 +35,7 @@ export const projectConfigSchema = v.object({
 	$schema: v.string(),
 	repos: v.optional(v.array(v.string()), []),
 	includeTests: v.boolean(),
+	includeDocs: v.optional(v.boolean(), false),
 	paths: pathsSchema,
 	configFiles: v.optional(v.record(v.string(), v.string())),
 	watermark: v.optional(v.boolean(), true),
@@ -85,6 +86,7 @@ export const registryConfigSchema = v.object({
 	excludeDeps: v.optional(v.array(v.string()), []),
 	allowSubdirectories: v.optional(v.boolean()),
 	preview: v.optional(v.boolean()),
+	includeDocs: v.optional(v.boolean(), false),
 	rules: v.optional(ruleConfigSchema),
 });
 

--- a/src/utils/mcp.ts
+++ b/src/utils/mcp.ts
@@ -103,6 +103,11 @@ const getComponentCodeTool: Tool = {
 				description: 'Should tests be included with the component code.',
 				default: false,
 			},
+			includeDocs: {
+				type: 'boolean',
+				description: 'Should docs be included with the component code.',
+				default: false,
+			},
 		},
 		required: ['component'],
 	},
@@ -111,9 +116,14 @@ const getComponentCodeTool: Tool = {
 interface GetComponentCodeArgs {
 	component: string;
 	includeTests?: boolean;
+	includeDocs?: boolean;
 }
 
-async function getComponentCode({ component, includeTests = false }: GetComponentCodeArgs) {
+async function getComponentCode({
+	component,
+	includeTests = false,
+	includeDocs = false,
+}: GetComponentCodeArgs) {
 	const provider = registry.selectProvider(component);
 
 	if (!provider) {
@@ -152,7 +162,7 @@ async function getComponentCode({ component, includeTests = false }: GetComponen
 		throw new Error(`${specifier} does not exist in ${repo}`);
 	}
 
-	const preloaded = preloadBlocks([block], { includeTests });
+	const preloaded = preloadBlocks([block], { includeTests, includeDocs });
 
 	const files = (await Promise.all(preloaded.map((p) => p.files))).flatMap((p) => [
 		...p.map((f) => ({ name: f.name, content: f.content.unwrapOr('<FETCH ERROR>') })),

--- a/tests/build.test.ts
+++ b/tests/build.test.ts
@@ -73,6 +73,7 @@ describe('build', () => {
 			listCategories: [],
 			excludeDeps: [],
 			allowSubdirectories: true,
+			includeDocs: true,
 		};
 
 		fs.writeFileSync('jsrepo-build-config.json', JSON.stringify(buildConfig));
@@ -142,6 +143,13 @@ export const schema = v.object({});`
 export const add = (a: number, b: number) => a b;
 
 export const logAnswer = (a: number, b: number) => log(\`Answer is: \${add(a, b)}\`);`
+		);
+
+		fs.writeFileSync(
+			'./src/utils/add.md',
+			`# Add
+
+This is a test`
 		);
 
 		fs.writeFileSync(
@@ -247,6 +255,7 @@ export const highlighter = createHighlighterCore({
 							dependencies: ['shiki', '@shikijs/themes', '@shikijs/langs'],
 							devDependencies: [],
 							tests: false,
+							docs: false,
 							list: true,
 							directory: 'src/svelte',
 							subdirectory: false,
@@ -265,6 +274,7 @@ export const highlighter = createHighlighterCore({
 							dependencies: ['shiki', '@shikijs/themes', '@shikijs/langs'],
 							devDependencies: [],
 							tests: false,
+							docs: false,
 							list: true,
 							directory: 'src/ts',
 							subdirectory: false,
@@ -283,6 +293,7 @@ export const highlighter = createHighlighterCore({
 							dependencies: [],
 							devDependencies: [],
 							tests: false,
+							docs: false,
 							list: true,
 							directory: 'src/types',
 							subdirectory: false,
@@ -301,10 +312,11 @@ export const highlighter = createHighlighterCore({
 							dependencies: [],
 							devDependencies: [],
 							tests: false,
+							docs: true,
 							list: true,
 							directory: 'src/utils',
 							subdirectory: false,
-							files: ['add.ts'],
+							files: ['add.ts', 'add.md'],
 							_imports_: {
 								'./log': '{{utils/log}}',
 							},
@@ -316,6 +328,7 @@ export const highlighter = createHighlighterCore({
 							dependencies: ['valibot@1.0.0-beta.14'],
 							devDependencies: [],
 							tests: false,
+							docs: false,
 							list: true,
 							directory: 'src/utils/form1',
 							subdirectory: true,
@@ -329,6 +342,7 @@ export const highlighter = createHighlighterCore({
 							dependencies: ['chalk@^5.3.0'],
 							devDependencies: [],
 							tests: false,
+							docs: false,
 							list: true,
 							directory: 'src/utils',
 							subdirectory: false,
@@ -342,6 +356,7 @@ export const highlighter = createHighlighterCore({
 							dependencies: [],
 							devDependencies: [],
 							tests: false,
+							docs: false,
 							list: true,
 							directory: 'src/utils',
 							subdirectory: false,
@@ -386,76 +401,120 @@ const defaultConfig = {
 
 describe('shouldListBlock', () => {
 	it('lists if unspecified', () => {
-		expect(shouldListBlock('a', { ...defaultConfig })).toBe(true);
+		expect(shouldListBlock('a', { ...defaultConfig, includeDocs: false })).toBe(true);
 	});
 
 	it('lists when should list', () => {
-		expect(shouldListBlock('a', { ...defaultConfig, listBlocks: ['a'] })).toBe(true);
-		expect(shouldListBlock('a', { ...defaultConfig, doNotListBlocks: ['b'] })).toBe(true);
+		expect(
+			shouldListBlock('a', { ...defaultConfig, listBlocks: ['a'], includeDocs: false })
+		).toBe(true);
+		expect(
+			shouldListBlock('a', { ...defaultConfig, doNotListBlocks: ['b'], includeDocs: false })
+		).toBe(true);
 	});
 
 	it('does not list when should not list', () => {
-		expect(shouldListBlock('a', { ...defaultConfig, listBlocks: ['b'] })).toBe(false);
-		expect(shouldListBlock('a', { ...defaultConfig, doNotListBlocks: ['a'] })).toBe(false);
+		expect(
+			shouldListBlock('a', { ...defaultConfig, listBlocks: ['b'], includeDocs: false })
+		).toBe(false);
+		expect(
+			shouldListBlock('a', { ...defaultConfig, doNotListBlocks: ['a'], includeDocs: false })
+		).toBe(false);
 	});
 });
 
 describe('shouldListCategory', () => {
 	it('lists if unspecified', () => {
-		expect(shouldListCategory('a', { ...defaultConfig })).toBe(true);
+		expect(shouldListCategory('a', { ...defaultConfig, includeDocs: false })).toBe(true);
 	});
 
 	it('lists when should list', () => {
-		expect(shouldListCategory('a', { ...defaultConfig, listCategories: ['a'] })).toBe(true);
-		expect(shouldListCategory('a', { ...defaultConfig, doNotListCategories: ['b'] })).toBe(
-			true
-		);
+		expect(
+			shouldListCategory('a', { ...defaultConfig, listCategories: ['a'], includeDocs: false })
+		).toBe(true);
+		expect(
+			shouldListCategory('a', {
+				...defaultConfig,
+				doNotListCategories: ['b'],
+				includeDocs: false,
+			})
+		).toBe(true);
 	});
 
 	it('does not list when should not list', () => {
-		expect(shouldListCategory('a', { ...defaultConfig, listCategories: ['b'] })).toBe(false);
-		expect(shouldListCategory('a', { ...defaultConfig, doNotListCategories: ['a'] })).toBe(
-			false
-		);
+		expect(
+			shouldListCategory('a', { ...defaultConfig, listCategories: ['b'], includeDocs: false })
+		).toBe(false);
+		expect(
+			shouldListCategory('a', {
+				...defaultConfig,
+				doNotListCategories: ['a'],
+				includeDocs: false,
+			})
+		).toBe(false);
 	});
 });
 
 describe('shouldIncludeBlock', () => {
 	it('lists if unspecified', () => {
-		expect(shouldIncludeBlock('a', { ...defaultConfig })).toBe(true);
+		expect(shouldIncludeBlock('a', { ...defaultConfig, includeDocs: false })).toBe(true);
 	});
 
 	it('lists when should list', () => {
-		expect(shouldIncludeBlock('a', { ...defaultConfig, includeBlocks: ['a'] })).toBe(true);
-		expect(shouldIncludeBlock('a', { ...defaultConfig, excludeBlocks: ['b'] })).toBe(true);
+		expect(
+			shouldIncludeBlock('a', { ...defaultConfig, includeBlocks: ['a'], includeDocs: false })
+		).toBe(true);
+		expect(
+			shouldIncludeBlock('a', { ...defaultConfig, excludeBlocks: ['b'], includeDocs: false })
+		).toBe(true);
 	});
 
 	it('does not list when should not list', () => {
-		expect(shouldIncludeBlock('a', { ...defaultConfig, includeBlocks: ['b'] })).toBe(false);
-		expect(shouldIncludeBlock('a', { ...defaultConfig, excludeBlocks: ['a'] })).toBe(false);
+		expect(
+			shouldIncludeBlock('a', { ...defaultConfig, includeBlocks: ['b'], includeDocs: false })
+		).toBe(false);
+		expect(
+			shouldIncludeBlock('a', { ...defaultConfig, excludeBlocks: ['a'], includeDocs: false })
+		).toBe(false);
 	});
 });
 
 describe('shouldIncludeCategory', () => {
 	it('lists if unspecified', () => {
-		expect(shouldIncludeCategory('a', { ...defaultConfig })).toBe(true);
+		expect(shouldIncludeCategory('a', { ...defaultConfig, includeDocs: false })).toBe(true);
 	});
 
 	it('lists when should list', () => {
-		expect(shouldIncludeCategory('a', { ...defaultConfig, includeCategories: ['a'] })).toBe(
-			true
-		);
-		expect(shouldIncludeCategory('a', { ...defaultConfig, excludeCategories: ['b'] })).toBe(
-			true
-		);
+		expect(
+			shouldIncludeCategory('a', {
+				...defaultConfig,
+				includeCategories: ['a'],
+				includeDocs: false,
+			})
+		).toBe(true);
+		expect(
+			shouldIncludeCategory('a', {
+				...defaultConfig,
+				excludeCategories: ['b'],
+				includeDocs: false,
+			})
+		).toBe(true);
 	});
 
 	it('does not list when should not list', () => {
-		expect(shouldIncludeCategory('a', { ...defaultConfig, includeCategories: ['b'] })).toBe(
-			false
-		);
-		expect(shouldIncludeCategory('a', { ...defaultConfig, excludeCategories: ['a'] })).toBe(
-			false
-		);
+		expect(
+			shouldIncludeCategory('a', {
+				...defaultConfig,
+				includeCategories: ['b'],
+				includeDocs: false,
+			})
+		).toBe(false);
+		expect(
+			shouldIncludeCategory('a', {
+				...defaultConfig,
+				excludeCategories: ['a'],
+				includeDocs: false,
+			})
+		).toBe(false);
 	});
 });


### PR DESCRIPTION
Alternative to #538 

Fixes #537 

This PR enables registry owners to include documentation files (*.md, *.mdx) in their registry. This can help users (or llms) with the usage of registry items. Just like tests adding documentations files is opt-in with the `includeDocs` config key.

@Asuniia thank you for your initial work on this I have added you as a co-author on this PR. Also apologies for how long this took! 