### PR TITLE
fix: Ensure blocks can resolve blocks built out of a different `dir`

### DIFF
--- a/.changeset/puny-plums-refuse.md
+++ b/.changeset/puny-plums-refuse.md
@@ -1,0 +1,6 @@
+---
+"jsrepo": patch
+---
+
+fix: Ensure blocks can resolve blocks built out of a different `dir`
+  

--- a/src/utils/language-support/index.ts
+++ b/src/utils/language-support/index.ts
@@ -203,22 +203,11 @@ function resolveLocalImport(
 ): Result<ResolveLocalImportResult | undefined, string> {
 	if (isSubDir && (mod.startsWith('./') || mod === '.')) return Ok(undefined);
 
-	// get the path to the current category
-	// if the block is a subdirectory block then containing dir must exist
-	const categoryDir = isSubDir ? path.join(containingDir!, '../') : path.join(filePath, '../');
-
 	// get the actual path to the module
 	const modPath = path.join(path.join(filePath, '../'), mod);
 
-	// get the full path to the current category containing folder
-	const fullDir = path.join(categoryDir, '../');
-
 	// prevent self reference in subdirectories
 	if (containingDir && modPath.startsWith(containingDir)) return Ok(undefined);
-
-	if (modPath.startsWith(fullDir)) {
-		return Ok(parsePath(modPath.slice(fullDir.length), dropExtension));
-	}
 
 	const absPath = path.resolve(modPath);
 


### PR DESCRIPTION
Fixes #587 

The code from #552 made the code removed here unnecessary and in fact, incorrect.