### PR TITLE
fix: Resolve tsconfig references

### DIFF
--- a/.changeset/fifty-eggs-cheer.md
+++ b/.changeset/fifty-eggs-cheer.md
@@ -1,0 +1,6 @@
+---
+"jsrepo": patch
+---
+
+fix: Resolve tsconfig references
+  

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -13,7 +13,6 @@ import {
 } from '@clack/prompts';
 import color from 'chalk';
 import { Command, Option, program } from 'commander';
-import { createPathsMatcher } from 'get-tsconfig';
 import { detect, resolveCommand } from 'package-manager-detector';
 import path from 'pathe';
 import * as v from 'valibot';
@@ -31,7 +30,7 @@ import {
 	getRegistryConfig,
 } from '../utils/config';
 import { packageJson } from '../utils/context';
-import { formatFile, matchJSDescendant, tryGetTsconfig } from '../utils/files';
+import { formatFile, matchJSDescendant } from '../utils/files';
 import { loadFormatterConfig } from '../utils/format';
 import { json } from '../utils/language-support';
 import type { PackageJson } from '../utils/package';
@@ -46,6 +45,7 @@ import {
 } from '../utils/prompts';
 import * as registry from '../utils/registry-providers/internal';
 import { TokenManager } from '../utils/token-manager';
+import { createPathsMatcher, tryGetTsconfig } from '../utils/tsconfig';
 
 const schema = v.object({
 	repos: v.optional(v.array(v.string())),
@@ -203,7 +203,7 @@ const _initProject = async (registries: string[], options: Options) => {
 						return error;
 					}
 
-					const matcher = createPathsMatcher(tsconfigResult);
+					const matcher = createPathsMatcher(tsconfigResult, { cwd: options.cwd });
 
 					if (matcher) {
 						const found = matcher(value);

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import color from 'chalk';
-import { createPathsMatcher } from 'get-tsconfig';
 import path from 'pathe';
 import * as v from 'valibot';
 import {
@@ -12,7 +11,7 @@ import {
 } from '../types';
 import { Err, Ok, type Result } from './blocks/ts/result';
 import { ruleConfigSchema } from './build/check';
-import { tryGetTsconfig } from './files';
+import { createPathsMatcher, tryGetTsconfig } from './tsconfig';
 
 /** Files and directories ignore by default during build/publish */
 export const IGNORES = ['.git', 'node_modules', '.DS_Store'] as const;
@@ -113,7 +112,7 @@ export type RegistryConfig = v.InferOutput<typeof registryConfigSchema>;
 export function resolvePaths(paths: Paths, cwd: string): Result<Paths, string> {
 	const config = tryGetTsconfig(cwd).unwrapOr(null);
 
-	const matcher = config ? createPathsMatcher(config) : null;
+	const matcher = config ? createPathsMatcher(config, { cwd }) : null;
 
 	const newPaths: Paths = { '*': '' };
 

--- a/src/utils/files.ts
+++ b/src/utils/files.ts
@@ -147,29 +147,3 @@ export function matchJSDescendant(searchFilePath: string): string | undefined {
 
 	return undefined;
 }
-
-/** Attempts to get the js/tsconfig file for the searched path
- *
- * @param searchPath
- * @returns
- */
-export function tryGetTsconfig(searchPath?: string): Result<TsConfigResult | null, string> {
-	let config: TsConfigResult | null;
-
-	try {
-		config = getTsconfig(searchPath, 'tsconfig.json');
-
-		if (!config) {
-			// if we don't find the config at first check for a jsconfig
-			config = getTsconfig(searchPath, 'jsconfig.json');
-
-			if (!config) {
-				return Ok(null);
-			}
-		}
-	} catch (err) {
-		return Err(`Error while trying to get ${color.bold('tsconfig.json')}: ${err}`);
-	}
-
-	return Ok(config);
-}

--- a/src/utils/language-support/index.ts
+++ b/src/utils/language-support/index.ts
@@ -2,7 +2,6 @@ import fs from 'node:fs';
 import { builtinModules } from 'node:module';
 import type { PartialConfiguration } from '@biomejs/wasm-nodejs';
 import color from 'chalk';
-import { createPathsMatcher } from 'get-tsconfig';
 import path from 'pathe';
 import type * as prettier from 'prettier';
 import validatePackageName from 'validate-npm-package-name';
@@ -10,9 +9,9 @@ import * as ascii from '../ascii';
 import * as lines from '../blocks/ts/lines';
 import { Err, Ok, type Result } from '../blocks/ts/result';
 import type { Formatter } from '../config';
-import { tryGetTsconfig } from '../files';
 import { findNearestPackageJson } from '../package';
 import { parsePackageName } from '../parse-package-name';
+import { createPathsMatcher, tryGetTsconfig } from '../tsconfig';
 import { css } from './css';
 import { html } from './html';
 import { typescript } from './javascript';
@@ -287,7 +286,7 @@ function tryResolveLocalAlias(
 
 	if (config === null) return Ok(undefined);
 
-	const matcher = createPathsMatcher(config);
+	const matcher = createPathsMatcher(config, { cwd });
 
 	if (matcher) {
 		// if the mod is actually remote the returns paths will be empty

--- a/src/utils/tsconfig.ts
+++ b/src/utils/tsconfig.ts
@@ -1,0 +1,84 @@
+import fs from 'node:fs';
+import color from 'chalk';
+import { type TsConfigResult, createPathsMatcher, getTsconfig } from 'get-tsconfig';
+import path from 'pathe';
+import { Err, Ok, type Result } from './blocks/ts/result';
+
+/** Attempts to get the js/tsconfig file for the searched path
+ *
+ * @param searchPath
+ * @returns
+ */
+export function tryGetTsconfig(
+	searchPath?: string,
+	fileName?: string
+): Result<TsConfigResult | null, string> {
+	let config: TsConfigResult | null;
+
+	try {
+		config = getTsconfig(searchPath, fileName);
+
+		if (!config) {
+			// if we don't find the config at first check for a jsconfig
+			config = getTsconfig(searchPath, fileName);
+
+			if (!config) {
+				return Ok(null);
+			}
+		}
+	} catch (err) {
+		return Err(`Error while trying to get ${color.bold(fileName || 'tsconfig.json')}: ${err}`);
+	}
+
+	return Ok(config);
+}
+
+export function _createPathsMatcher(
+	configResult: TsConfigResult,
+	{ cwd }: { cwd: string }
+): ((specifier: string) => string[]) | null {
+	// resolve tsconfig references
+	if (configResult.config.references) {
+		for (const configPath of configResult.config.references) {
+			const configPathOrDir = path.join(cwd, configPath.path);
+
+			let directory: string;
+			let fileName = 'tsconfig.json';
+
+			// references can be a file or a directory https://www.typescriptlang.org/docs/handbook/project-references.html
+			if (fs.existsSync(configPathOrDir)) {
+				if (fs.statSync(configPathOrDir).isFile()) {
+					directory = path.dirname(configPathOrDir);
+					fileName = path.basename(configPathOrDir);
+				} else {
+					directory = configPathOrDir;
+				}
+			} else {
+				continue;
+			}
+
+			const config = tryGetTsconfig(directory, fileName).unwrapOr(null);
+
+			if (config === null) continue;
+
+			const paths: Record<string, string[]> = {};
+
+			for (const [key, value] of Object.entries(config.config.compilerOptions?.paths ?? {})) {
+				// this way if the referenced tsconfig is in a different directory it will be resolved as expected
+				paths[key] = value.map((v) => path.join(directory, v));
+			}
+
+			configResult.config.compilerOptions = {
+				...configResult.config.compilerOptions,
+				paths: {
+					...configResult.config.compilerOptions?.paths,
+					...paths,
+				},
+			};
+		}
+	}
+
+	return createPathsMatcher(configResult);
+}
+
+export { _createPathsMatcher as createPathsMatcher };


### PR DESCRIPTION
Fixes #606 

With this PR users are now able to have tsconfig files that make use of the `references` top level key. In this approach we simply wrap `createPathsMatcher` from `get-tsconfig` and resolve and append any of the paths from referenced tsconfigs to the paths in the base tsconfig before creating the paths matcher just like before.