### PR TITLE
fix: prevent out-of-memory when resolving cyclic dependency graphs

### DIFF
--- a/.changeset/beige-states-lick.md
+++ b/.changeset/beige-states-lick.md
@@ -1,0 +1,6 @@
+---
+"jsrepo": patch
+---
+
+fix: prevent out-of-memory when resolving cyclic dependency graphs
+  


### PR DESCRIPTION
Hi @ieedan 
was able to find the root cause for the OOM if there were cyclic dependencies. 
- resolveTree() rebuilt a local blocks map per recursive call and only passed that one level down via the installed parameter, losing “visited” context at deeper levels. This allowed cycles across more than one level to loop indefinitely.
- With a cycle (e.g. A -> B -> C -> A), the recursion could revisit A because the ancestor’s visited state had been dropped at deeper levels.

With this fix, the installation of blocks is now functional if the published blocks include expected cyclic dependencies (`"no-circular-dependency": "warn"`). 🎉