### PR TITLE
feat: allow --no-cache to controls the cache of fetching manifest

### DIFF
--- a/src/commands/add.ts
+++ b/src/commands/add.ts
@@ -276,6 +276,7 @@ async function _add(blockNames: string[], options: Options) {
 	const manifests = (
 		await registry.fetchManifests(resolvedRepos, {
 			verbose: options.verbose ? verbose : undefined,
+			noCache: !options.cache,
 		})
 	).match(
 		(v) => v,


### PR DESCRIPTION
My issue situation:

After `jsrepo build`, I pushed result to my self-hosted server. However, when using `jsrepo add` in my project, it prompts "Invalid block! my/block does not exist!".
But when I changed the server's port without making any other modifications, `jsrepo add` worked successfully.

Therefore, I suspect it is caused by the cache when fetching the manifest. I checked the code and it seems that `--no-cache` only controls the cache strategy of the git provider.

My modification is to apply --no-cache to `internalFetchManifest` -> `iFetch`