### PR TITLE
feat: unified plugins array for jsrepo config

### DIFF
--- a/packages/bun/src/index.ts
+++ b/packages/bun/src/index.ts
@@ -52,6 +52,14 @@ export function bun(): RemoteDependencyResolver {
 	};
 }
 
+export default function bunPlugin() {
+	return definePlugin({
+		build: {
+			remoteDependencyResolver: bun(),
+		},
+	});
+}
+
 type BunWorkspaceState = {
 	workspacePackages: Map<string, string>;
 };

--- a/packages/jsrepo/src/api/config.ts
+++ b/packages/jsrepo/src/api/config.ts
@@ -14,6 +14,8 @@ export {
 	type TransformOptions,
 } from '@/utils/config';
 export { loadConfigSearch } from '@/utils/config/utils';
+export { definePlugin, type JsrepoPlugin, type JsrepoPluginFactory } from '@/utils/plugins';
+export { type PartialConfig, resolveConfig } from '@/utils/config/resolve';
 export type {
 	AfterArgs,
 	AfterHook,

--- a/packages/jsrepo/src/api/config.ts
+++ b/packages/jsrepo/src/api/config.ts
@@ -14,7 +14,12 @@ export {
 	type TransformOptions,
 } from '@/utils/config';
 export { loadConfigSearch } from '@/utils/config/utils';
-export { definePlugin, type JsrepoPlugin, type JsrepoPluginFactory } from '@/utils/plugins';
+export {
+	definePlugin,
+	type JsrepoPlugin,
+	type JsrepoPluginFactory,
+	type JsrepoPluginHooks,
+} from '@/utils/plugins';
 export { type PartialConfig, resolveConfig } from '@/utils/config/resolve';
 export type {
 	AfterArgs,

--- a/packages/jsrepo/src/commands/config/index.ts
+++ b/packages/jsrepo/src/commands/config/index.ts
@@ -1,11 +1,13 @@
 import { Command } from 'commander';
 import { language } from '@/commands/config/language';
 import { mcp } from '@/commands/config/mcp';
+import { plugin } from '@/commands/config/plugin';
 import { provider } from '@/commands/config/provider';
 import { transform } from '@/commands/config/transform';
 
 export const config = new Command('config')
 	.description('Modify your jsrepo config.')
+	.addCommand(plugin)
 	.addCommand(transform)
 	.addCommand(provider)
 	.addCommand(language)

--- a/packages/jsrepo/src/commands/config/language.ts
+++ b/packages/jsrepo/src/commands/config/language.ts
@@ -86,7 +86,7 @@ export async function runLanguage(
 
 	const newCodeResult = await addPluginsToConfig({
 		plugins: languages,
-		key: 'languages',
+		key: 'plugins',
 		config: { path: config.path, code },
 	});
 	if (newCodeResult.isErr()) return err(newCodeResult.error);

--- a/packages/jsrepo/src/commands/config/plugin.ts
+++ b/packages/jsrepo/src/commands/config/plugin.ts
@@ -23,17 +23,17 @@ export const schema = defaultCommandOptionsSchema.extend({
 	yes: z.boolean(),
 });
 
-export type ConfigAddTransformOptions = z.infer<typeof schema>;
+export type ConfigAddPluginOptions = z.infer<typeof schema>;
 
-export const transform = new Command('transform')
-	.description('Add a transform to your config.')
+export const plugin = new Command('plugin')
+	.description('Add a plugin to your config.')
 	.argument(
-		'[transforms...]',
-		'Names of the transforms you want to add to your config. ex: (@jsrepo/transform-prettier, @jsrepo/transform-biome)'
+		'[plugins...]',
+		'Names of the plugins you want to add to your config. ex: (@jsrepo/transform-prettier, @jsrepo/shadcn)'
 	)
 	.addOption(commonOptions.cwd)
 	.addOption(commonOptions.yes)
-	.action(async (transforms, rawOptions) => {
+	.action(async (pluginsArg, rawOptions) => {
 		const options = parseOptions(schema, rawOptions);
 
 		const configResult = await loadConfigSearch({
@@ -44,49 +44,49 @@ export const transform = new Command('transform')
 
 		const config = configResult.config;
 		const cwd = path.dirname(configResult.path) as AbsolutePath;
-		const transformOptions = { ...options, cwd };
+		const pluginOptions = { ...options, cwd };
 
 		await runBeforeHooks(
 			config,
-			{ command: 'config.transform', options: transformOptions },
+			{ command: 'config.plugin', options: pluginOptions },
 			{ cwd, yes: options.yes }
 		);
 
 		intro();
 
-		const result = await tryCommand(runTransform(transforms, transformOptions, configResult));
+		const result = await tryCommand(runPlugin(pluginsArg, pluginOptions, configResult));
 
 		outro(formatResult(result));
 
 		await runAfterHooks(
 			config,
-			{ command: 'config.transform', options: transformOptions, result },
+			{ command: 'config.plugin', options: pluginOptions, result },
 			{ cwd }
 		);
 	});
 
-export type ConfigAddTransformCommandResult = {
+export type ConfigAddPluginCommandResult = {
 	duration: number;
-	transforms: number;
+	plugins: number;
 };
 
-export async function runTransform(
-	transformsArg: string[],
-	options: ConfigAddTransformOptions,
+export async function runPlugin(
+	pluginsArg: string[],
+	options: ConfigAddPluginOptions,
 	config: { config: Config; path: AbsolutePath }
-): Promise<Result<ConfigAddTransformCommandResult, CLIError>> {
+): Promise<Result<ConfigAddPluginCommandResult, CLIError>> {
 	const start = performance.now();
 
-	const transformsResult = parsePlugins(transformsArg, 'transform');
-	if (transformsResult.isErr()) return err(transformsResult.error);
-	const transforms = transformsResult.value;
+	const pluginsResult = parsePlugins(pluginsArg, 'plugin');
+	if (pluginsResult.isErr()) return err(pluginsResult.error);
+	const plugins = pluginsResult.value;
 
 	const codeResult = readFileSync(config.path);
 	if (codeResult.isErr()) return err(codeResult.error);
 	const code = codeResult.value;
 
 	const newCodeResult = await addPluginsToConfig({
-		plugins: transforms,
+		plugins,
 		key: 'plugins',
 		config: { path: config.path, code },
 	});
@@ -98,9 +98,9 @@ export async function runTransform(
 
 	await promptInstallDependencies(
 		{
-			devDependencies: transforms.map((transform) => ({
-				name: transform.packageName,
-				version: transform.version,
+			devDependencies: plugins.map((plugin) => ({
+				name: plugin.packageName,
+				version: plugin.version,
 			})),
 			dependencies: [],
 		},
@@ -110,14 +110,14 @@ export async function runTransform(
 	const end = performance.now();
 	const duration = end - start;
 
-	return ok({ duration, transforms: transformsArg.length });
+	return ok({ duration, plugins: pluginsArg.length });
 }
 
 export function formatResult({
 	duration,
-	transforms: items,
-}: ConfigAddTransformCommandResult): string {
-	return `Added ${pc.green(items.toString())} ${items > 1 ? 'transforms' : 'transform'} in ${pc.green(
+	plugins: items,
+}: ConfigAddPluginCommandResult): string {
+	return `Added ${pc.green(items.toString())} ${items > 1 ? 'plugins' : 'plugin'} in ${pc.green(
 		`${duration.toFixed(2)}ms`
 	)}.`;
 }

--- a/packages/jsrepo/src/commands/config/provider.ts
+++ b/packages/jsrepo/src/commands/config/provider.ts
@@ -88,7 +88,7 @@ export async function runProvider(
 
 	const newCodeResult = await addPluginsToConfig({
 		plugins: providers,
-		key: 'providers',
+		key: 'plugins',
 		config: { path: config.path, code },
 	});
 	if (newCodeResult.isErr()) return err(newCodeResult.error);

--- a/packages/jsrepo/src/commands/init.ts
+++ b/packages/jsrepo/src/commands/init.ts
@@ -482,7 +482,7 @@ async function initPlugins(
 		const wantedPlugins = getWantedPluginsResult.value;
 		const addPluginsToConfigResult = await addPluginsToConfig({
 			plugins: wantedPlugins,
-			key: key as keyof typeof registry.manifest.plugins,
+			key: 'plugins',
 			config: { path: configPath, code: configCode },
 		});
 		if (addPluginsToConfigResult.isErr()) return err(addPluginsToConfigResult.error);
@@ -590,7 +590,7 @@ async function getWantedPlugins(
 	const unAddedPlugins = await neededPlugins({ config, plugins });
 	for (const plugin of unAddedPlugins) {
 		if (pluginChoices.has(plugin.package)) continue;
-		const parsePluginNameResult = parsePluginName(plugin.package, type);
+		const parsePluginNameResult = parsePluginName(plugin.package, 'plugin');
 		if (parsePluginNameResult.isErr()) return err(parsePluginNameResult.error);
 		const pluginName = parsePluginNameResult.value.name;
 		const mappedPlugin: Plugin = {

--- a/packages/jsrepo/src/utils/config/index.ts
+++ b/packages/jsrepo/src/utils/config/index.ts
@@ -11,6 +11,7 @@ import type {
 	MaybePromise,
 	Prettify,
 } from '@/utils/types';
+import { resolveConfig, type PartialConfig } from '@/utils/config/resolve';
 import { extract, type MaybeGetterAsync } from '@/utils/utils';
 import type { Warning } from '@/utils/warnings';
 
@@ -377,20 +378,9 @@ export type Transform = {
 	}) => Promise<{ code?: string; fileName?: ItemRelativePath }>;
 };
 
-export function defineConfig(config: Partial<Config> | (() => Partial<Config>)): Config {
-	const c = extract(config);
+export type { PartialConfig } from '@/utils/config/resolve';
+export { resolveConfig } from '@/utils/config/resolve';
 
-	return {
-		providers: c.providers ?? DEFAULT_PROVIDERS,
-		registries: c.registries ?? [],
-		registry: c.registry ?? [],
-		languages: c.languages ?? DEFAULT_LANGS,
-		transforms: c.transforms ?? [],
-		paths: c.paths ?? {},
-		hooks: c.hooks,
-		build: {
-			onwarn: c.build?.onwarn ?? c.onwarn,
-			...c.build,
-		},
-	};
+export function defineConfig(config: PartialConfig | (() => PartialConfig)): Config {
+	return resolveConfig(extract(config)) as Config;
 }

--- a/packages/jsrepo/src/utils/config/index.ts
+++ b/packages/jsrepo/src/utils/config/index.ts
@@ -3,7 +3,6 @@ import { DEFAULT_LANGS, type Language } from '@/langs';
 import type { Output } from '@/outputs/types';
 import { DEFAULT_PROVIDERS, type ProviderFactory } from '@/providers';
 import type { RemoteDependency, UnresolvedFile } from '@/utils/build';
-import type { AfterHook, BeforeHook } from '@/utils/hooks';
 import type {
 	AbsolutePath,
 	ItemRelativePath,
@@ -142,8 +141,8 @@ export type Config = {
 	 * ```
 	 */
 	hooks?: {
-		after?: AfterHook | AfterHook[];
-		before?: BeforeHook | BeforeHook[];
+		after?: import('@/utils/hooks').AfterHook | import('@/utils/hooks').AfterHook[];
+		before?: import('@/utils/hooks').BeforeHook | import('@/utils/hooks').BeforeHook[];
 	};
 };
 

--- a/packages/jsrepo/src/utils/config/mods/add-plugins.ts
+++ b/packages/jsrepo/src/utils/config/mods/add-plugins.ts
@@ -55,7 +55,7 @@ export async function addPluginsToConfig({
 		code: string;
 	};
 	plugins: Plugin[];
-	key: 'transforms' | 'providers' | 'languages';
+	key: 'transforms' | 'providers' | 'languages' | 'plugins';
 }): Promise<
 	Result<string, InvalidKeyTypeError | CouldNotFindJsrepoImportError | ConfigObjectNotFoundError>
 > {
@@ -338,11 +338,23 @@ export const OFFICIAL_PLUGINS = [
 		shorthand: 'filecasing',
 		name: '@jsrepo/transform-filecasing',
 	},
+	{
+		shorthand: 'shadcn',
+		name: '@jsrepo/shadcn',
+	},
+	{
+		shorthand: 'pnpm',
+		name: '@jsrepo/pnpm',
+	},
+	{
+		shorthand: 'bun',
+		name: '@jsrepo/bun',
+	},
 ];
 
 export function parsePlugins(
 	plugins: string[],
-	key: 'transform' | 'provider' | 'language'
+	key: 'transform' | 'provider' | 'language' | 'plugin'
 ): Result<Plugin[], InvalidPluginError> {
 	const pluginsResult = plugins.map((plugin) => parsePluginName(plugin, key));
 	const finalPlugins: Plugin[] = [];
@@ -355,7 +367,7 @@ export function parsePlugins(
 
 export function parsePluginName(
 	plugin: string,
-	key: 'transform' | 'provider' | 'language'
+	key: 'transform' | 'provider' | 'language' | 'plugin'
 ): Result<Plugin, InvalidPluginError> {
 	const officialPlugin = OFFICIAL_PLUGINS.find((p) => p.shorthand === plugin);
 	if (officialPlugin) {
@@ -372,16 +384,18 @@ export function parsePluginName(
 	if (parsedPackage.isErr()) return err(new InvalidPluginError(plugin));
 
 	let name = parsedPackage.value.name;
+	const pluginKey = key === 'plugin' ? undefined : key;
 	if (parsedPackage.value.name.startsWith('@')) {
 		if (parsedPackage.value.name.startsWith('@jsrepo/')) {
-			if (!parsedPackage.value.name.split('/')[1]?.includes(key)) {
+			const packageSuffix = parsedPackage.value.name.split('/')[1]!;
+			if (pluginKey && !packageSuffix.includes(pluginKey)) {
 				// hack around names like @jsrepo/shadcn
-				name = `jsrepo-${key}-${parsedPackage.value.name.split('/')[1]!}`;
+				name = `jsrepo-${pluginKey}-${packageSuffix}`;
 			} else {
 				// add jsrepo- prefix back to official plugins
 				// instead of @jsrepo/transform-prettier
 				// we want jsrepo-transform-prettier
-				name = `jsrepo-${parsedPackage.value.name.split('/')[1]!}`;
+				name = `jsrepo-${packageSuffix}`;
 			}
 		} else {
 			// use the second portion of the name
@@ -392,7 +406,9 @@ export function parsePluginName(
 	}
 
 	return ok({
-		name: kebabToCamel(name.replace(`jsrepo-${key}-`, '')),
+		name: kebabToCamel(
+			pluginKey ? name.replace(`jsrepo-${pluginKey}-`, '') : name.replace(/^jsrepo-/, '')
+		),
 		packageName: parsedPackage.value.name,
 		version: parsedPackage.value.version,
 	});

--- a/packages/jsrepo/src/utils/config/plugin-types.ts
+++ b/packages/jsrepo/src/utils/config/plugin-types.ts
@@ -1,0 +1,52 @@
+import type { AbsolutePath, ItemRelativePath, LooseAutocomplete } from '@/utils/types';
+import type { MaybePromise } from '@/utils/types';
+import type { Warning } from '@/utils/warnings';
+
+export type RemoteDependency = {
+	ecosystem: string;
+	name: string;
+	version?: string;
+};
+
+export type UnresolvedFile = {
+	path: string;
+};
+
+export type RemoteDependencyResolverOptions = {
+	cwd: AbsolutePath;
+};
+
+export type RemoteDependencyResolver = (
+	dep: RemoteDependency,
+	options: RemoteDependencyResolverOptions
+) => MaybePromise<RemoteDependency>;
+
+export type BuildTransform = {
+	transform: (
+		content: string,
+		opts: { cwd: AbsolutePath; file: UnresolvedFile }
+	) => MaybePromise<{ content: string }>;
+};
+
+export type TransformOptions = {
+	cwd: AbsolutePath;
+	registryUrl: string;
+	item: {
+		name: string;
+		type: LooseAutocomplete<string>;
+	};
+};
+
+export type Transform = {
+	transform: (opts: {
+		code: string;
+		fileName: ItemRelativePath;
+		options: TransformOptions;
+	}) => Promise<{ code?: string; fileName?: ItemRelativePath }>;
+};
+
+export type ConfigBuild = {
+	onwarn?: (warning: Warning, handler: (message: Warning) => void) => void;
+	transforms?: BuildTransform[];
+	remoteDependencyResolver?: RemoteDependencyResolver;
+};

--- a/packages/jsrepo/src/utils/config/resolve.ts
+++ b/packages/jsrepo/src/utils/config/resolve.ts
@@ -1,0 +1,97 @@
+import { DEFAULT_LANGS } from '@/langs';
+import type { Language } from '@/langs/types';
+import { DEFAULT_PROVIDERS } from '@/providers';
+import type { ProviderFactory } from '@/providers/types';
+import type { AfterHook, BeforeHook } from '@/utils/hooks';
+import {
+	resolveBuildTransformEntries,
+	resolveLanguageEntries,
+	resolvePluginContributionsList,
+	resolveProviderEntries,
+	resolveTransformEntries,
+} from '@/utils/plugins/normalize';
+import type {
+	BuildTransform,
+	PluginInput,
+	RemoteDependencyResolver,
+	Transform,
+} from '@/utils/plugins/types';
+import type { Warning } from '@/utils/warnings';
+
+export type ResolvedConfig = {
+	registries: string[];
+	registry: unknown;
+	providers: ProviderFactory[];
+	languages: Language[];
+	transforms: Transform[];
+	paths: Record<string, string | undefined>;
+	build: {
+		onwarn?: (warning: Warning, handler: (message: Warning) => void) => void;
+		transforms?: BuildTransform[];
+		remoteDependencyResolver?: RemoteDependencyResolver;
+	};
+	hooks?: {
+		after?: AfterHook | AfterHook[];
+		before?: BeforeHook | BeforeHook[];
+	};
+	onwarn?: (warning: Warning, handler: (message: Warning) => void) => void;
+};
+
+export type PartialConfig = Partial<
+	Omit<ResolvedConfig, 'build'> & {
+		build?: Partial<ResolvedConfig['build']>;
+	}
+> & {
+	plugins?: PluginInput[];
+};
+
+export function resolveConfig(c: PartialConfig): ResolvedConfig {
+	const pluginContributions = resolvePluginContributionsList(c.plugins);
+
+	const transforms = [
+		...pluginContributions.transforms,
+		...resolveTransformEntries(c.transforms),
+	];
+
+	const providers = [
+		...pluginContributions.providers,
+		...resolveProviderEntries(c.providers),
+	];
+
+	const languages = [
+		...pluginContributions.languages,
+		...resolveLanguageEntries(c.languages),
+	];
+
+	const buildTransforms = [
+		...(pluginContributions.build.transforms ?? []),
+		...resolveBuildTransformEntries(c.build?.transforms),
+	];
+
+	const build: ResolvedConfig['build'] = {
+		onwarn: c.build?.onwarn ?? c.onwarn ?? pluginContributions.build.onwarn,
+		...c.build,
+		...pluginContributions.build,
+	};
+
+	if (buildTransforms.length > 0) {
+		build.transforms = buildTransforms;
+	}
+
+	return {
+		providers:
+			c.providers !== undefined || pluginContributions.providers.length > 0
+				? providers
+				: DEFAULT_PROVIDERS,
+		registries: c.registries ?? [],
+		registry: c.registry ?? [],
+		languages:
+			c.languages !== undefined || pluginContributions.languages.length > 0
+				? languages
+				: DEFAULT_LANGS,
+		transforms,
+		paths: c.paths ?? {},
+		hooks: c.hooks,
+		build,
+	};
+}

--- a/packages/jsrepo/src/utils/config/resolve.ts
+++ b/packages/jsrepo/src/utils/config/resolve.ts
@@ -2,7 +2,6 @@ import { DEFAULT_LANGS } from '@/langs';
 import type { Language } from '@/langs/types';
 import { DEFAULT_PROVIDERS } from '@/providers';
 import type { ProviderFactory } from '@/providers/types';
-import type { AfterHook, BeforeHook } from '@/utils/hooks';
 import {
 	resolveBuildTransformEntries,
 	resolveLanguageEntries,
@@ -12,11 +11,57 @@ import {
 } from '@/utils/plugins/normalize';
 import type {
 	BuildTransform,
+	JsrepoPluginHooks,
 	PluginInput,
 	RemoteDependencyResolver,
 	Transform,
 } from '@/utils/plugins/types';
 import type { Warning } from '@/utils/warnings';
+
+type BeforeHook = import('@/utils/hooks').BeforeHook;
+type AfterHook = import('@/utils/hooks').AfterHook;
+
+type ConfigHooks = {
+	after?: AfterHook | AfterHook[];
+	before?: BeforeHook | BeforeHook[];
+};
+
+function normalizeBeforeHooks(hook: BeforeHook | BeforeHook[] | undefined): BeforeHook[] {
+	if (!hook) return [];
+	return Array.isArray(hook) ? hook : [hook];
+}
+
+function normalizeAfterHooks(hook: AfterHook | AfterHook[] | undefined): AfterHook[] {
+	if (!hook) return [];
+	return Array.isArray(hook) ? hook : [hook];
+}
+
+function mergeConfigHooks(
+	pluginHooks: JsrepoPluginHooks,
+	configHooks: ConfigHooks | undefined
+): ConfigHooks | undefined {
+	const before = [
+		...normalizeBeforeHooks(pluginHooks.before),
+		...normalizeBeforeHooks(configHooks?.before),
+	];
+	const after = [
+		...normalizeAfterHooks(pluginHooks.after),
+		...normalizeAfterHooks(configHooks?.after),
+	];
+
+	if (before.length === 0 && after.length === 0) {
+		return configHooks;
+	}
+
+	const merged: ConfigHooks = {};
+	if (before.length > 0) {
+		merged.before = before.length === 1 ? before[0]! : before;
+	}
+	if (after.length > 0) {
+		merged.after = after.length === 1 ? after[0]! : after;
+	}
+	return merged;
+}
 
 export type ResolvedConfig = {
 	registries: string[];
@@ -30,10 +75,7 @@ export type ResolvedConfig = {
 		transforms?: BuildTransform[];
 		remoteDependencyResolver?: RemoteDependencyResolver;
 	};
-	hooks?: {
-		after?: AfterHook | AfterHook[];
-		before?: BeforeHook | BeforeHook[];
-	};
+	hooks?: ConfigHooks;
 	onwarn?: (warning: Warning, handler: (message: Warning) => void) => void;
 };
 
@@ -91,7 +133,7 @@ export function resolveConfig(c: PartialConfig): ResolvedConfig {
 				: DEFAULT_LANGS,
 		transforms,
 		paths: c.paths ?? {},
-		hooks: c.hooks,
+		hooks: mergeConfigHooks(pluginContributions.hooks, c.hooks),
 		build,
 	};
 }

--- a/packages/jsrepo/src/utils/config/utils.ts
+++ b/packages/jsrepo/src/utils/config/utils.ts
@@ -4,6 +4,7 @@ import path from 'pathe';
 import { createConfigLoader } from 'unconfig';
 import type { AbsolutePath } from '@/api/utils';
 import type { Config } from '@/utils/config';
+import { resolveConfig, type PartialConfig } from '@/utils/config/resolve';
 import { ConfigNotFoundError, FailedToLoadConfigError } from '@/utils/errors';
 import { createPathsMatcher, type PathsMatcher, tryGetTsconfig } from '@/utils/tsconfig';
 
@@ -54,7 +55,7 @@ export function loadConfigOptional({
 			const loadResult = await _createConfigLoader({ cwd }).load();
 			if (loadResult.sources.length === 0) return null;
 
-			return loadResult.config;
+			return resolveConfig(loadResult.config as PartialConfig) as Config;
 		})(),
 		(err) => new FailedToLoadConfigError(err)
 	);
@@ -78,7 +79,10 @@ export async function loadConfigSearch({
 	const loadResult = await _createConfigLoader({ cwd }).load();
 
 	if (loadResult.sources.length > 0) {
-		return { config: loadResult.config, path: loadResult.sources[0]! as AbsolutePath };
+		return {
+			config: resolveConfig(loadResult.config as PartialConfig) as Config,
+			path: loadResult.sources[0]! as AbsolutePath,
+		};
 	}
 
 	let shouldContinue = !promptForContinueIfNull;

--- a/packages/jsrepo/src/utils/plugins/index.ts
+++ b/packages/jsrepo/src/utils/plugins/index.ts
@@ -1,0 +1,23 @@
+import type { JsrepoPlugin } from '@/utils/plugins/types';
+
+export type {
+	JsrepoPlugin,
+	JsrepoPluginBuild,
+	JsrepoPluginFactory,
+	PluginInput,
+	ResolvedPluginContributions,
+} from '@/utils/plugins/types';
+export {
+	resolveBuildTransformEntries,
+	resolveLanguageEntries,
+	resolvePluginContributions,
+	resolvePluginContributionsList,
+	resolveProviderEntries,
+	resolveTransformEntries,
+} from '@/utils/plugins/normalize';
+/**
+ * Creates a jsrepo plugin object. Use this when authoring plugin packages.
+ */
+export function definePlugin(plugin: JsrepoPlugin): JsrepoPlugin {
+	return plugin;
+}

--- a/packages/jsrepo/src/utils/plugins/index.ts
+++ b/packages/jsrepo/src/utils/plugins/index.ts
@@ -4,6 +4,7 @@ export type {
 	JsrepoPlugin,
 	JsrepoPluginBuild,
 	JsrepoPluginFactory,
+	JsrepoPluginHooks,
 	PluginInput,
 	ResolvedPluginContributions,
 } from '@/utils/plugins/types';

--- a/packages/jsrepo/src/utils/plugins/normalize.ts
+++ b/packages/jsrepo/src/utils/plugins/normalize.ts
@@ -4,6 +4,7 @@ import type {
 	BuildTransform,
 	JsrepoPlugin,
 	JsrepoPluginBuild,
+	JsrepoPluginHooks,
 	PluginInput,
 	ResolvedPluginContributions,
 } from '@/utils/plugins/types';
@@ -14,7 +15,37 @@ const EMPTY_CONTRIBUTIONS: ResolvedPluginContributions = {
 	providers: [],
 	languages: [],
 	build: {},
+	hooks: {},
 };
+
+function normalizeBeforeHooks(
+	hook: JsrepoPluginHooks['before']
+): NonNullable<JsrepoPluginHooks['before']>[] {
+	if (!hook) return [];
+	return Array.isArray(hook) ? hook : [hook];
+}
+
+function normalizeAfterHooks(
+	hook: JsrepoPluginHooks['after']
+): NonNullable<JsrepoPluginHooks['after']>[] {
+	if (!hook) return [];
+	return Array.isArray(hook) ? hook : [hook];
+}
+
+function mergeHooks(
+	target: JsrepoPluginHooks,
+	source: JsrepoPluginHooks | undefined
+): JsrepoPluginHooks {
+	if (!source) return target;
+
+	const before = [...normalizeBeforeHooks(target.before), ...normalizeBeforeHooks(source.before)];
+	const after = [...normalizeAfterHooks(target.after), ...normalizeAfterHooks(source.after)];
+
+	return {
+		...(before.length > 0 ? { before: before.length === 1 ? before[0]! : before } : {}),
+		...(after.length > 0 ? { after: after.length === 1 ? after[0]! : after } : {}),
+	};
+}
 
 function isTransform(value: PluginInput): value is Transform {
 	return (
@@ -60,7 +91,8 @@ function isJsrepoPlugin(value: PluginInput): value is JsrepoPlugin {
 		'transforms' in value ||
 		'providers' in value ||
 		'languages' in value ||
-		'build' in value
+		'build' in value ||
+		'hooks' in value
 	);
 }
 
@@ -88,6 +120,7 @@ function appendContributions(
 		providers: [...target.providers, ...source.providers],
 		languages: [...target.languages, ...source.languages],
 		build: mergeBuild(target.build, source.build),
+		hooks: mergeHooks(target.hooks, source.hooks),
 	};
 }
 
@@ -98,6 +131,7 @@ export function resolvePluginContributions(plugin: PluginInput): ResolvedPluginC
 			providers: plugin.providers ?? [],
 			languages: plugin.languages ?? [],
 			build: plugin.build ?? {},
+			hooks: plugin.hooks ?? {},
 		};
 	}
 

--- a/packages/jsrepo/src/utils/plugins/normalize.ts
+++ b/packages/jsrepo/src/utils/plugins/normalize.ts
@@ -1,0 +1,170 @@
+import type { Language } from '@/langs/types';
+import type { ProviderFactory } from '@/providers/types';
+import type {
+	BuildTransform,
+	JsrepoPlugin,
+	JsrepoPluginBuild,
+	PluginInput,
+	ResolvedPluginContributions,
+} from '@/utils/plugins/types';
+import type { RemoteDependencyResolver, Transform } from '@/utils/config/plugin-types';
+
+const EMPTY_CONTRIBUTIONS: ResolvedPluginContributions = {
+	transforms: [],
+	providers: [],
+	languages: [],
+	build: {},
+};
+
+function isTransform(value: PluginInput): value is Transform {
+	return (
+		typeof value === 'object' &&
+		value !== null &&
+		'transform' in value &&
+		typeof value.transform === 'function'
+	);
+}
+
+function isProviderFactory(value: PluginInput): value is ProviderFactory {
+	return (
+		typeof value === 'object' &&
+		value !== null &&
+		'name' in value &&
+		'matches' in value &&
+		'create' in value &&
+		typeof value.matches === 'function' &&
+		typeof value.create === 'function'
+	);
+}
+
+function isLanguage(value: PluginInput): value is Language {
+	return (
+		typeof value === 'object' &&
+		value !== null &&
+		'name' in value &&
+		'canResolveDependencies' in value &&
+		'resolveDependencies' in value &&
+		'transformImports' in value
+	);
+}
+
+function isRemoteDependencyResolver(value: PluginInput): value is RemoteDependencyResolver {
+	return typeof value === 'function';
+}
+
+function isJsrepoPlugin(value: PluginInput): value is JsrepoPlugin {
+	if (typeof value !== 'object' || value === null) return false;
+	if (isTransform(value) || isProviderFactory(value) || isLanguage(value)) return false;
+
+	return (
+		'transforms' in value ||
+		'providers' in value ||
+		'languages' in value ||
+		'build' in value
+	);
+}
+
+function mergeBuild(
+	target: JsrepoPluginBuild,
+	source: JsrepoPluginBuild | undefined
+): JsrepoPluginBuild {
+	if (!source) return target;
+
+	const merged: JsrepoPluginBuild = { ...target, ...source };
+
+	if (source.transforms) {
+		merged.transforms = [...(target.transforms ?? []), ...source.transforms];
+	}
+
+	return merged;
+}
+
+function appendContributions(
+	target: ResolvedPluginContributions,
+	source: ResolvedPluginContributions
+): ResolvedPluginContributions {
+	return {
+		transforms: [...target.transforms, ...source.transforms],
+		providers: [...target.providers, ...source.providers],
+		languages: [...target.languages, ...source.languages],
+		build: mergeBuild(target.build, source.build),
+	};
+}
+
+export function resolvePluginContributions(plugin: PluginInput): ResolvedPluginContributions {
+	if (isJsrepoPlugin(plugin)) {
+		return {
+			transforms: plugin.transforms ?? [],
+			providers: plugin.providers ?? [],
+			languages: plugin.languages ?? [],
+			build: plugin.build ?? {},
+		};
+	}
+
+	if (isTransform(plugin)) {
+		return { ...EMPTY_CONTRIBUTIONS, transforms: [plugin] };
+	}
+
+	if (isProviderFactory(plugin)) {
+		return { ...EMPTY_CONTRIBUTIONS, providers: [plugin] };
+	}
+
+	if (isLanguage(plugin)) {
+		return { ...EMPTY_CONTRIBUTIONS, languages: [plugin] };
+	}
+
+	if (isRemoteDependencyResolver(plugin)) {
+		return {
+			...EMPTY_CONTRIBUTIONS,
+			build: { remoteDependencyResolver: plugin },
+		};
+	}
+
+	return EMPTY_CONTRIBUTIONS;
+}
+
+export function resolvePluginContributionsList(
+	plugins: PluginInput[] | undefined
+): ResolvedPluginContributions {
+	if (!plugins?.length) return EMPTY_CONTRIBUTIONS;
+
+	return plugins.reduce(
+		(accumulated, plugin) => appendContributions(accumulated, resolvePluginContributions(plugin)),
+		EMPTY_CONTRIBUTIONS
+	);
+}
+
+export function resolveTransformEntries(
+	entries: (Transform | JsrepoPlugin)[] | undefined
+): Transform[] {
+	if (!entries?.length) return [];
+
+	return entries.flatMap((entry) => resolvePluginContributions(entry).transforms);
+}
+
+export function resolveProviderEntries(
+	entries: (ProviderFactory | JsrepoPlugin)[] | undefined
+): ProviderFactory[] {
+	if (!entries?.length) return [];
+
+	return entries.flatMap((entry) => resolvePluginContributions(entry).providers);
+}
+
+export function resolveLanguageEntries(entries: (Language | JsrepoPlugin)[] | undefined): Language[] {
+	if (!entries?.length) return [];
+
+	return entries.flatMap((entry) => resolvePluginContributions(entry).languages);
+}
+
+export function resolveBuildTransformEntries(
+	entries: (BuildTransform | JsrepoPlugin)[] | undefined
+): BuildTransform[] {
+	if (!entries?.length) return [];
+
+	return entries.flatMap((entry) => {
+		if (typeof entry === 'object' && entry !== null && 'transform' in entry) {
+			return [entry as BuildTransform];
+		}
+		return resolvePluginContributions(entry as PluginInput).build.transforms ?? [];
+	});
+}

--- a/packages/jsrepo/src/utils/plugins/types.ts
+++ b/packages/jsrepo/src/utils/plugins/types.ts
@@ -1,0 +1,41 @@
+import type { Language } from '@/langs/types';
+import type { ProviderFactory } from '@/providers/types';
+import type {
+	BuildTransform,
+	RemoteDependencyResolver,
+	Transform,
+} from '@/utils/config/plugin-types';
+import type { Warning } from '@/utils/warnings';
+
+export type { BuildTransform, RemoteDependencyResolver, Transform } from '@/utils/config/plugin-types';
+
+export type JsrepoPluginBuild = {
+	transforms?: BuildTransform[];
+	remoteDependencyResolver?: RemoteDependencyResolver;
+	onwarn?: (warning: Warning, handler: (message: Warning) => void) => void;
+};
+
+export type JsrepoPlugin = {
+	transforms?: Transform[];
+	providers?: ProviderFactory[];
+	languages?: Language[];
+	build?: JsrepoPluginBuild;
+};
+
+export type JsrepoPluginFactory<TOptions = void> = TOptions extends void
+	? () => JsrepoPlugin
+	: (options: TOptions) => JsrepoPlugin;
+
+export type ResolvedPluginContributions = {
+	transforms: Transform[];
+	providers: ProviderFactory[];
+	languages: Language[];
+	build: JsrepoPluginBuild;
+};
+
+export type PluginInput =
+	| JsrepoPlugin
+	| Transform
+	| ProviderFactory
+	| Language
+	| RemoteDependencyResolver;

--- a/packages/jsrepo/src/utils/plugins/types.ts
+++ b/packages/jsrepo/src/utils/plugins/types.ts
@@ -9,6 +9,11 @@ import type { Warning } from '@/utils/warnings';
 
 export type { BuildTransform, RemoteDependencyResolver, Transform } from '@/utils/config/plugin-types';
 
+export type JsrepoPluginHooks = {
+	before?: import('@/utils/hooks').BeforeHook | import('@/utils/hooks').BeforeHook[];
+	after?: import('@/utils/hooks').AfterHook | import('@/utils/hooks').AfterHook[];
+};
+
 export type JsrepoPluginBuild = {
 	transforms?: BuildTransform[];
 	remoteDependencyResolver?: RemoteDependencyResolver;
@@ -20,6 +25,7 @@ export type JsrepoPlugin = {
 	providers?: ProviderFactory[];
 	languages?: Language[];
 	build?: JsrepoPluginBuild;
+	hooks?: JsrepoPluginHooks;
 };
 
 export type JsrepoPluginFactory<TOptions = void> = TOptions extends void
@@ -31,6 +37,7 @@ export type ResolvedPluginContributions = {
 	providers: ProviderFactory[];
 	languages: Language[];
 	build: JsrepoPluginBuild;
+	hooks: JsrepoPluginHooks;
 };
 
 export type PluginInput =

--- a/packages/jsrepo/tests/config.test.ts
+++ b/packages/jsrepo/tests/config.test.ts
@@ -1,5 +1,7 @@
-import { defineConfig } from 'jsrepo';
 import { describe, expect, it } from 'vitest';
+import { defineConfig } from '@/utils/config';
+import type { Transform } from '@/utils/config';
+import { definePlugin } from '@/utils/plugins';
 
 describe('config', () => {
 	it('should add default providers', () => {
@@ -24,5 +26,15 @@ describe('config', () => {
 			languages: [],
 		});
 		expect(config.languages.length === 0).toBe(true);
+	});
+
+	it('should resolve plugins from the unified plugins array', () => {
+		const sampleTransform: Transform = {
+			transform: async ({ code }) => ({ code }),
+		};
+		const config = defineConfig({
+			plugins: [definePlugin({ transforms: [sampleTransform] })],
+		});
+		expect(config.transforms).toHaveLength(1);
 	});
 });

--- a/packages/jsrepo/tests/config.test.ts
+++ b/packages/jsrepo/tests/config.test.ts
@@ -1,28 +1,28 @@
 import { describe, expect, it } from 'vitest';
-import { defineConfig } from '@/utils/config';
-import type { Transform } from '@/utils/config';
+import { resolveConfig } from '@/utils/config/resolve';
 import { definePlugin } from '@/utils/plugins';
+import type { Transform } from '@/utils/plugins/types';
 
 describe('config', () => {
 	it('should add default providers', () => {
-		const config = defineConfig({});
+		const config = resolveConfig({});
 		expect(config.providers.length > 0).toBe(true);
 	});
 
 	it('should override default providers', () => {
-		const config = defineConfig({
+		const config = resolveConfig({
 			providers: [],
 		});
 		expect(config.providers.length === 0).toBe(true);
 	});
 
 	it('should add default langs', () => {
-		const config = defineConfig({});
+		const config = resolveConfig({});
 		expect(config.languages.length > 0).toBe(true);
 	});
 
 	it('should override default langs', () => {
-		const config = defineConfig({
+		const config = resolveConfig({
 			languages: [],
 		});
 		expect(config.languages.length === 0).toBe(true);
@@ -32,7 +32,7 @@ describe('config', () => {
 		const sampleTransform: Transform = {
 			transform: async ({ code }) => ({ code }),
 		};
-		const config = defineConfig({
+		const config = resolveConfig({
 			plugins: [definePlugin({ transforms: [sampleTransform] })],
 		});
 		expect(config.transforms).toHaveLength(1);

--- a/packages/jsrepo/tests/plugins.test.ts
+++ b/packages/jsrepo/tests/plugins.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+import { resolveConfig } from '@/utils/config/resolve';
+import { definePlugin } from '@/utils/plugins';
+import type { Transform } from '@/utils/plugins/types';
+import { resolvePluginContributions, resolvePluginContributionsList } from '@/utils/plugins/normalize';
+
+const sampleTransform: Transform = {
+	transform: async ({ code }) => ({ code }),
+};
+
+describe('plugins', () => {
+	it('should resolve a transform plugin contribution', () => {
+		const contributions = resolvePluginContributions(sampleTransform);
+		expect(contributions.transforms).toHaveLength(1);
+	});
+
+	it('should resolve a unified plugin object', () => {
+		const contributions = resolvePluginContributions(
+			definePlugin({
+				transforms: [sampleTransform],
+			})
+		);
+		expect(contributions.transforms).toHaveLength(1);
+	});
+
+	it('should unwrap transforms passed in the legacy transforms array', () => {
+		const config = resolveConfig({
+			transforms: [
+				definePlugin({
+					transforms: [sampleTransform],
+				}),
+			],
+		});
+		expect(config.transforms).toHaveLength(1);
+	});
+
+	it('should merge plugins with legacy fields', () => {
+		const config = resolveConfig({
+			plugins: [
+				definePlugin({
+					transforms: [sampleTransform],
+				}),
+			],
+			transforms: [sampleTransform],
+		});
+		expect(config.transforms).toHaveLength(2);
+	});
+
+	it('should resolve build contributions from plugins', () => {
+		const resolver = async () => ({ ecosystem: 'js', name: 'foo' });
+		const contributions = resolvePluginContributionsList([
+			definePlugin({
+				build: {
+					remoteDependencyResolver: resolver,
+				},
+			}),
+		]);
+		expect(contributions.build.remoteDependencyResolver).toBe(resolver);
+	});
+
+	it('should apply plugins through resolveConfig', () => {
+		const config = resolveConfig({
+			plugins: [
+				definePlugin({
+					transforms: [sampleTransform],
+				}),
+			],
+		});
+		expect(config.transforms).toHaveLength(1);
+	});
+});

--- a/packages/jsrepo/tests/plugins.test.ts
+++ b/packages/jsrepo/tests/plugins.test.ts
@@ -68,4 +68,51 @@ describe('plugins', () => {
 		});
 		expect(config.transforms).toHaveLength(1);
 	});
+
+	it('should merge hooks from plugins and config', () => {
+		const pluginBefore = async () => {};
+		const configBefore = async () => {};
+		const pluginAfter = 'plugin-after';
+		const configAfter = 'config-after';
+
+		const config = resolveConfig({
+			plugins: [
+				definePlugin({
+					hooks: {
+						before: pluginBefore,
+						after: pluginAfter,
+					},
+				}),
+			],
+			hooks: {
+				before: configBefore,
+				after: configAfter,
+			},
+		});
+
+		expect(Array.isArray(config.hooks?.before)).toBe(true);
+		expect((config.hooks?.before as unknown[]).length).toBe(2);
+		expect((config.hooks?.before as unknown[])[0]).toBe(pluginBefore);
+		expect((config.hooks?.before as unknown[])[1]).toBe(configBefore);
+
+		expect(Array.isArray(config.hooks?.after)).toBe(true);
+		expect((config.hooks?.after as unknown[]).length).toBe(2);
+		expect((config.hooks?.after as unknown[])[0]).toBe(pluginAfter);
+		expect((config.hooks?.after as unknown[])[1]).toBe(configAfter);
+	});
+
+	it('should merge hooks from multiple plugins in order', () => {
+		const first = async () => {};
+		const second = async () => {};
+
+		const config = resolveConfig({
+			plugins: [
+				definePlugin({ hooks: { before: first } }),
+				definePlugin({ hooks: { before: second } }),
+			],
+		});
+
+		expect((config.hooks?.before as unknown[])[0]).toBe(first);
+		expect((config.hooks?.before as unknown[])[1]).toBe(second);
+	});
 });

--- a/packages/jsrepo/tests/utils/add-plugins-to-config.test.ts
+++ b/packages/jsrepo/tests/utils/add-plugins-to-config.test.ts
@@ -568,4 +568,41 @@ describe('parsePluginName', () => {
 			version: undefined,
 		});
 	});
+
+	it('should parse unified plugin names', () => {
+		const result = parsePluginName('@jsrepo/shadcn', 'plugin');
+		expect(result._unsafeUnwrap()).toEqual({
+			name: 'shadcn',
+			packageName: '@jsrepo/shadcn',
+			version: undefined,
+		});
+	});
+
+	it('should add plugins to the unified plugins array', async () => {
+		const configCode = dedent`import { defineConfig } from 'jsrepo';
+
+        export default defineConfig({
+            registries: [],
+        });
+        `;
+
+		const result = await addPluginsToConfig({
+			plugins: [
+				{
+					name: 'prettier',
+					packageName: '@jsrepo/transform-prettier',
+					version: undefined,
+				},
+			],
+			config: {
+				code: configCode,
+				path: 'jsrepo.config.ts',
+			},
+			key: 'plugins',
+		});
+
+		const updated = result._unsafeUnwrap();
+		expect(updated).toContain("import prettier from '@jsrepo/transform-prettier'");
+		expect(updated).toContain('plugins: [prettier()]');
+	});
 });

--- a/packages/pnpm/src/index.ts
+++ b/packages/pnpm/src/index.ts
@@ -107,6 +107,14 @@ export function pnpm(): RemoteDependencyResolver {
 	};
 }
 
+export default function pnpmPlugin() {
+	return definePlugin({
+		build: {
+			remoteDependencyResolver: pnpm(),
+		},
+	});
+}
+
 const stateCache = new Map<string, ParsedState>();
 
 function getOrParseState(cwd: string): ParsedState {

--- a/packages/shadcn/src/index.ts
+++ b/packages/shadcn/src/index.ts
@@ -10,7 +10,29 @@ import { parsePackageName } from './utils';
 
 export * from './output';
 
-export { provider as default } from './provider';
+import { definePlugin } from 'jsrepo';
+import { provider, type ShadcnOptions } from './provider';
+
+export { provider } from './provider';
+
+/**
+ * Shadcn registry provider plugin for jsrepo.
+ *
+ * @example
+ * ```ts
+ * import { defineConfig } from "jsrepo";
+ * import shadcn from "@jsrepo/shadcn";
+ *
+ * export default defineConfig({
+ *   plugins: [shadcn()],
+ * });
+ * ```
+ */
+export default function shadcn(options: ShadcnOptions = {}) {
+	return definePlugin({
+		providers: [provider(options)],
+	});
+}
 
 export type ShadcnRegistryItemType = (typeof registryItemTypeSchema.options)[number];
 

--- a/packages/transform-biome/src/index.ts
+++ b/packages/transform-biome/src/index.ts
@@ -1,8 +1,8 @@
 import { Biome, Distribution } from '@biomejs/js-api';
-import type { Transform } from 'jsrepo';
+import { definePlugin, type Transform } from 'jsrepo';
 
 /**
- * A transform plugin for jsrepo to format code with prettier.
+ * A transform plugin for jsrepo to format code with biome.
  * @example
  * ```ts
  * import { defineConfig } from "jsrepo";
@@ -10,13 +10,11 @@ import type { Transform } from 'jsrepo';
  *
  * export default defineConfig({
  *  // ...
- *  transforms: [biome()],
+ *  plugins: [biome()],
  * });
  * ```
- *
- * @param options - The options for the transform plugin.
  */
-export default function (): Transform {
+export function createBiomeTransform(): Transform {
 	return {
 		transform: async ({ code, fileName, options }) => {
 			return {
@@ -39,4 +37,10 @@ async function tryFormat(code: string, { fileName, cwd }: { fileName: string; cw
 		console.error(err);
 		return undefined;
 	}
+}
+
+export default function biome() {
+	return definePlugin({
+		transforms: [createBiomeTransform()],
+	});
 }

--- a/packages/transform-filecasing/src/index.ts
+++ b/packages/transform-filecasing/src/index.ts
@@ -1,5 +1,5 @@
 import { camelCase, kebabCase, pascalCase, snakeCase } from 'change-case';
-import type { Transform } from 'jsrepo';
+import { definePlugin, type Transform } from 'jsrepo';
 import type { ItemRelativePath } from 'jsrepo/utils';
 
 export type CaseType = 'kebab' | 'camel' | 'snake' | 'pascal';
@@ -27,13 +27,13 @@ const caseTransformers: Record<CaseType, (input: string) => string> = {
  *
  * export default defineConfig({
  *  // ...
- *  transforms: [fileCasing({ to: "camel" })],
+ *  plugins: [fileCasing({ to: "camel" })],
  * });
  * ```
  *
  * @param options - The options for the transform plugin.
  */
-export default function ({
+export function createFileCasingTransform({
 	to = 'kebab',
 	transformDirectories = true,
 }: Partial<Options> = {}): Transform {
@@ -74,4 +74,10 @@ export default function ({
 			};
 		},
 	};
+}
+
+export default function fileCasing(options: Partial<Options> = {}) {
+	return definePlugin({
+		transforms: [createFileCasingTransform(options)],
+	});
 }

--- a/packages/transform-javascript/src/index.ts
+++ b/packages/transform-javascript/src/index.ts
@@ -1,5 +1,5 @@
 import { strip } from '@svecosystem/strip-types';
-import type { Transform } from 'jsrepo';
+import { definePlugin, type Transform } from 'jsrepo';
 import { Unreachable } from 'jsrepo/errors';
 import type { ItemRelativePath } from 'jsrepo/utils';
 import { transform } from 'sucrase';
@@ -31,13 +31,15 @@ export const SUPPORTED_EXTENSIONS: FileExtension[] = [
  *
  * export default defineConfig({
  *  // ...
- *  transforms: [stripTypes()],
+ *  plugins: [stripTypes()],
  * });
  * ```
  *
  * @param options - The options for the transform plugin.
  */
-export default function ({ supportedExtensions = SUPPORTED_EXTENSIONS }: Options = {}): Transform {
+export function createJavascriptTransform({
+	supportedExtensions = SUPPORTED_EXTENSIONS,
+}: Options = {}): Transform {
 	return {
 		transform: async ({ code, fileName }) => {
 			if (
@@ -86,4 +88,10 @@ function updateFileExtension(
 		}
 	}
 	throw new Unreachable();
+}
+
+export default function stripTypes(options: Options = {}) {
+	return definePlugin({
+		transforms: [createJavascriptTransform(options)],
+	});
 }

--- a/packages/transform-oxfmt/src/index.ts
+++ b/packages/transform-oxfmt/src/index.ts
@@ -1,4 +1,4 @@
-import type { Transform } from 'jsrepo';
+import { definePlugin, type Transform } from 'jsrepo';
 import { type FormatOptions, format } from 'oxfmt';
 
 /**
@@ -10,13 +10,13 @@ import { type FormatOptions, format } from 'oxfmt';
  *
  * export default defineConfig({
  *  // ...
- *  transforms: [oxfmt()],
+ *  plugins: [oxfmt()],
  * });
  * ```
  *
  * @param options - The options for the transform plugin.
  */
-export default function (options: FormatOptions = {}): Transform {
+export function createOxfmtTransform(options: FormatOptions = {}): Transform {
 	return {
 		transform: async ({ code, fileName }) => {
 			return { code: await tryFormat(fileName, code, options) };
@@ -38,4 +38,10 @@ async function tryFormat(
 	} catch {
 		return undefined;
 	}
+}
+
+export default function oxfmt(options: FormatOptions = {}) {
+	return definePlugin({
+		transforms: [createOxfmtTransform(options)],
+	});
 }

--- a/packages/transform-prettier/src/index.ts
+++ b/packages/transform-prettier/src/index.ts
@@ -1,5 +1,5 @@
 import path from 'node:path';
-import type { Transform } from 'jsrepo';
+import { definePlugin, type Transform } from 'jsrepo';
 import { type Config, format, resolveConfig } from 'prettier';
 
 export type Options = {
@@ -16,13 +16,13 @@ export type Options = {
  *
  * export default defineConfig({
  *  // ...
- *  transforms: [prettier()],
+ *  plugins: [prettier()],
  * });
  * ```
  *
  * @param options - The options for the transform plugin.
  */
-export default function (options: Options = {}): Transform {
+export function createPrettierTransform(options: Options = {}): Transform {
 	const configPromise = resolveConfig(
 		path.join(process.cwd(), options.configFile ?? '.prettierrc')
 	);
@@ -45,4 +45,10 @@ function tryFormat(
 	} catch {
 		return undefined;
 	}
+}
+
+export default function prettier(options: Options = {}) {
+	return definePlugin({
+		transforms: [createPrettierTransform(options)],
+	});
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Introduces a unified top-level `plugins` array in `jsrepo.config` that can combine transforms, providers, languages, build settings, and **lifecycle hooks** from a single list. Plugin packages export a **default factory** returning a `JsrepoPlugin` object.

## Plugin contributions

| Field | Description |
|-------|-------------|
| `transforms` | Add-time code transforms |
| `providers` | Registry URL providers |
| `languages` | Dependency resolution / import rewriting |
| `build` | Build transforms, `remoteDependencyResolver`, `onwarn` |
| `hooks` | `before` / `after` CLI lifecycle hooks |

Plugin hooks run **first** (in `plugins` array order), then any top-level `hooks` in the config.

## Example

```ts
import { defineConfig, definePlugin } from "jsrepo";

export default defineConfig({
  plugins: [
    definePlugin({
      hooks: {
        before: async ({ command }) => console.log(`Running ${command}...`),
        after: "echo done",
      },
    }),
  ],
});
```

Legacy `hooks`, `transforms`, `providers`, `languages`, and `build` fields remain fully supported.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-aa2257ba-0ed5-4d75-9115-8be06c83eeb9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-aa2257ba-0ed5-4d75-9115-8be06c83eeb9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

